### PR TITLE
Fixing #49 - pink color to show/hide description

### DIFF
--- a/css/schedule.css
+++ b/css/schedule.css
@@ -279,7 +279,7 @@ header a {
     float: right;
 }
 #show-descriptions i {
-    color: #fc6e1f;
+    color: #D93F5F;
 }
 
 #filter-form {


### PR DESCRIPTION

As per #49 I choose the color from <3 tab, All tab and set it to the Show/Hide Description buttons.

PS: the on/off <3 from sessions have a different share of pink #B94D60; I choose the tab ones at the button is closed to that area

Is that the color you wanted @cassiemc ?
r? @mmmavis