### PR TITLE
Template block fixes

### DIFF
--- a/index.html
+++ b/index.html
@@ -45,6 +45,9 @@
 
         <script type="text/template" id="session-list-template">
         <div id="saturday" class="schedule-tab">
+            <h3><span>Saturday 8 AM</span></h3>
+            <div id="saturday-registration" class="page-block"><div class="open-block">OPEN</div></div>
+
             <h3><span>Saturday 9 AM</span></h3>
             <div id="saturday-opening-keynotes" class="page-block"><div class="open-block">OPEN</div></div>
 
@@ -74,6 +77,9 @@
         </div>
         
         <div id="sunday" class="schedule-tab">
+            <h3><span>Sunday 9 AM</span></h3>
+            <div id="sunday-registration" class="page-block"><div class="open-block">OPEN</div></div>
+
             <h3><span>Sunday 10 AM</span></h3>
             <div id="sunday-opening-circle" class="page-block"><div class="open-block">OPEN</div></div>
 

--- a/index.html
+++ b/index.html
@@ -71,7 +71,6 @@
 
             <h3><span>Saturday Party</span></h3>
             <div id="saturday-evening-main-stage" class="page-block"><div class="open-block">OPEN</div></div>
-
         </div>
         
         <div id="sunday" class="schedule-tab">
@@ -182,7 +181,7 @@
                             <a href="#_space-<%= slugify(session.space) %>"><%= session.space %></a><% } %><% if (session.location) { %>, <%= smartypants(session.location) %><% } %>
                     </div>
                     <% } %>
-                    <% if (session.pathwayArray) { %>
+                    <% if (session.pathways && session.pathwayArray.length) { %>
                     <div class="session-pathways">
                         <% session.pathwayArray.forEach(function(name, index) { %><% if (index > 0) { %>, <% } %>
                             <a href="#_pathway-<%= slugify(name) %>"><%= name %></a><% }) %>

--- a/index.html
+++ b/index.html
@@ -45,8 +45,8 @@
 
         <script type="text/template" id="session-list-template">
         <div id="saturday" class="schedule-tab">
-            <h3><span>Saturday 9:00 AM</span></h3>
-            <div id="saturday-opening-circle" class="page-block"><div class="open-block">OPEN</div></div>
+            <h3><span>Saturday 9 AM</span></h3>
+            <div id="saturday-opening-keynotes" class="page-block"><div class="open-block">OPEN</div></div>
 
             <h3><span>All Day Saturday</span></h3>
             <div id="all-saturday" class="page-block"><div class="open-block">OPEN</div></div>
@@ -74,7 +74,7 @@
         </div>
         
         <div id="sunday" class="schedule-tab">
-            <h3><span>Sunday Opening Circle</span></h3>
+            <h3><span>Sunday 10 AM</span></h3>
             <div id="sunday-opening-circle" class="page-block"><div class="open-block">OPEN</div></div>
 
             <h3><span>All Day Sunday</span></h3>

--- a/js/schedule.js
+++ b/js/schedule.js
@@ -364,6 +364,7 @@ function Schedule(options) {
         schedule.$container.html(schedule.sessionListTemplate);
         schedule.addCaptionOverline("<h2>" + schedule.filterKey + ": " + schedule.filterValue.replace(/-/g," ") + "</h2>");
         schedule.addSessionsToSchedule(schedule.filteredList);
+        schedule.clearOpenBlocks();
         schedule.transitionElementIn(schedule.$container);
     }
 


### PR DESCRIPTION
* Updates Saturday/Sunday templates to display main stage data, adds Friday science fair block https://github.com/mozilla/mozfest-schedule-app/issues/74
* removes open blocks from pathway views https://github.com/mozilla/mozfest-schedule-app/issues/73
* removes extraneous pathways icon from session detail views without pathways https://github.com/mozilla/mozfest-schedule-app/issues/69